### PR TITLE
Resolves #38

### DIFF
--- a/BackendServer/RMSError.swift
+++ b/BackendServer/RMSError.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum RMSErrorDomain : String {
+    case Backend = "RMSBackendErrorDomain"
+}
+
+extension NSError {
+    convenience init(domain: RMSErrorDomain, code: Int) {
+        self.init(domain: domain.rawValue, code: code, userInfo: nil)
+    }
+}

--- a/BackendServer/ViewController.swift
+++ b/BackendServer/ViewController.swift
@@ -24,15 +24,15 @@ class ViewController: UIViewController {
             }
         }
         
-        BackEndServer.submit(Snack(name: "Dotidos", description: ""), completionHandler: { (err: NSError?) -> Void in
+        var sn = "Doritos"
+        BackEndServer.submit(Snack(name: sn, description: ""), completionHandler: { (err: NSError?) -> Void in
             if err == nil {
-                println("snack saved")
+                println("snack \(sn) saved")
             } else if err?.code == RMSBackendError.Duplication.rawValue {
-                println("same snack found")
+                println("Already has \(sn)")
             }
         })
     }
-    
     
 }
 

--- a/RateMySnack.xcodeproj/project.pbxproj
+++ b/RateMySnack.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		2A0C19001B6466FB005A5F48 /* Snack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0C18FF1B6466FA005A5F48 /* Snack.swift */; };
 		2A0C19011B646723005A5F48 /* Snack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0C18FF1B6466FA005A5F48 /* Snack.swift */; };
 		7F67A94F1B5AF95400230509 /* BackendDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F67A94E1B5AF95400230509 /* BackendDelegate.swift */; };
+		7FAE99A01B9BF4780087B364 /* RMSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FAE999F1B9BF4780087B364 /* RMSError.swift */; };
+		7FAE99A11B9BF4780087B364 /* RMSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FAE999F1B9BF4780087B364 /* RMSError.swift */; };
 		7FE260151B5B5E9100F3288C /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FE260141B5B5E9100F3288C /* AudioToolbox.framework */; };
 		7FE260171B5B5E9800F3288C /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FE260161B5B5E9800F3288C /* CFNetwork.framework */; };
 		7FE260191B5B5EA700F3288C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FE260181B5B5EA700F3288C /* CoreGraphics.framework */; };
@@ -74,6 +76,7 @@
 		2A0C18FF1B6466FA005A5F48 /* Snack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Snack.swift; sourceTree = "<group>"; };
 		2A4AA0821B5B16FB00DDDA0B /* BackEndServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BackEndServer.swift; path = ../RateMySnack/BackEndServer.swift; sourceTree = "<group>"; };
 		7F67A94E1B5AF95400230509 /* BackendDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendDelegate.swift; sourceTree = "<group>"; };
+		7FAE999F1B9BF4780087B364 /* RMSError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RMSError.swift; path = ../BackendServer/RMSError.swift; sourceTree = "<group>"; };
 		7FE2600D1B5B5E6300F3288C /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Bolts.framework; sourceTree = "<group>"; };
 		7FE260111B5B5E7800F3288C /* Parse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Parse.framework; sourceTree = "<group>"; };
 		7FE260141B5B5E9100F3288C /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -254,6 +257,7 @@
 				C473686F1B50458400E97743 /* ViewController.swift */,
 				2A0C18FF1B6466FA005A5F48 /* Snack.swift */,
 				7F67A94E1B5AF95400230509 /* BackendDelegate.swift */,
+				7FAE999F1B9BF4780087B364 /* RMSError.swift */,
 				C47368711B50458400E97743 /* Main.storyboard */,
 				C47368741B50458400E97743 /* Images.xcassets */,
 				C47368761B50458400E97743 /* LaunchScreen.xib */,
@@ -451,6 +455,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7FE260541B5B612D00F3288C /* BackEndServer.swift in Sources */,
+				7FAE99A11B9BF4780087B364 /* RMSError.swift in Sources */,
 				7FE260391B5B610A00F3288C /* ViewController.swift in Sources */,
 				7FE260371B5B610A00F3288C /* AppDelegate.swift in Sources */,
 				7FE260551B5B616300F3288C /* BackendDelegate.swift in Sources */,
@@ -475,6 +480,7 @@
 				C47368701B50458400E97743 /* ViewController.swift in Sources */,
 				82B5308C1B644EC900B07F24 /* RMSStarView.swift in Sources */,
 				C473686E1B50458400E97743 /* AppDelegate.swift in Sources */,
+				7FAE99A01B9BF4780087B364 /* RMSError.swift in Sources */,
 				7FE260281B5B5F6B00F3288C /* BackEndServer.swift in Sources */,
 				2A0C19001B6466FB005A5F48 /* Snack.swift in Sources */,
 			);

--- a/RateMySnack/BackEndServer.swift
+++ b/RateMySnack/BackEndServer.swift
@@ -11,10 +11,10 @@ import Parse
 import Bolts
 
 class BackEndServer: BackendDelegate {
- 
+    
     static func submit(item: SnackProtocol, completionHandler completion: ((err: NSError?) -> Void)) {
         if BackEndServer.hasSnackNamed(item.name) {
-            completion(err: NSError(domain: "RMBackendError", code: RMSBackendError.Duplication.rawValue, userInfo: nil))
+            completion(err: NSError(domain: .Backend, code: RMSBackendError.Duplication.rawValue))
             return
         }
         // Creates an instance of AllSnack Object
@@ -29,10 +29,10 @@ class BackEndServer: BackendDelegate {
                 return
             }
             if error?.code == PFErrorCode.ErrorTimeout.rawValue {
-                completion(err: NSError(domain: "RMBackendError", code: RMSBackendError.Timeout.rawValue, userInfo: nil))
+                completion(err: NSError(domain: .Backend, code: RMSBackendError.Timeout.rawValue))
                 return
             }
-            completion(err: NSError(domain: "RMSBackendError", code: RMSBackendError.UnexpectedNetworkError.rawValue, userInfo: nil))//Lost coonnection
+            completion(err: NSError(domain: .Backend, code: RMSBackendError.UnexpectedNetworkError.rawValue)) //Lost coonnection
         }
     }
     
@@ -43,7 +43,7 @@ class BackEndServer: BackendDelegate {
         
         findSnacks.findObjectsInBackgroundWithBlock { (objects: [AnyObject]?, error: NSError?) -> Void in
             var nameOfSnack: [SnackProtocol] = []
-            if error == nil{
+            if error == nil {
                 if let objs = objects {
                     for i in objs {
                         var fo = Snack(name: i["SnackName"] as! String, description: "")
@@ -71,8 +71,8 @@ class BackEndServer: BackendDelegate {
         if err == nil  {
             // If objectsThatMatch is empty then return false otherwise return true
             if let objectsThatMatch2 = objectsThatMatch {
-                if objectsThatMatch2.count == 0{
-            return false
+                if objectsThatMatch2.count == 0 {
+                    return false
                 }
             }
         }

--- a/RateMySnack/BackendDelegate.swift
+++ b/RateMySnack/BackendDelegate.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 enum RMSBackendError : Int {
-    case Timeout = 1
-    case Duplication = 2
-    case UnexpectedNetworkError = 404
+    case Timeout
+    case Duplication
+    case UnexpectedNetworkError
 }
 
 /**


### PR DESCRIPTION
Removed explicit Numerical values from RMSBackendError to allow the compiler to automatically create them.
Add Error domains
Extend NSError to make it more simple.
